### PR TITLE
Check for '!theme' after we lower-case the message. Closes #24

### DIFF
--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -116,7 +116,7 @@ export default class ChatClient {
         if (self) { return; }
         if (!message) { return; }
 
-        if (message.startsWith('!theme')) {
+        if (message.toLocaleLowerCase().startsWith('!theme')) {
             await this._themer.handleCommands(userState["display-name"], '!theme', message.replace('!theme', '').trim());
         }
     }


### PR DESCRIPTION
# Purpose

As described in issue #24, somebody in chat may submit a '!theme' command using capital letters; we should still fire the command when such occurs.

# Changed files
- **ChatClient.ts** We simply needed to lowercase the message prior to checking to see if the message is a command or not.

![bitmoji](https://render.bitstrips.com/v2/cpanel/d6ea9573-7b6b-4374-bcf8-3c38eb0b0972-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)