### PR TITLE
New commands 'ban' and 'unban' have been added. Closes #4

### DIFF
--- a/src/commands/IListRecipient.ts
+++ b/src/commands/IListRecipient.ts
@@ -5,5 +5,7 @@ export interface IListRecipient {
     /** Username of the user who has requested the list of themes */
     username: string;
     /** Date the user was last sent the list of available themes */
-    lastSent: Date;
+    lastSent?: Date;
+    /** Whether or not the user has been banned or not */
+    banned?: boolean;
 }

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -49,10 +49,10 @@ export class Themer {
 
         let username: string  | undefined;
         /** Determine if the param is a (un)ban request */
-        const ban = param.match(/(?<subcommand>(?:un)?ban) (?<username>(\w)*)/);
+        const ban = param.match(/((?:un)?ban) (\w*)/);
         if (ban) {
-            param = ban.groups && ban.groups.subcommand || '';
-            username = ban.groups && ban.groups.username;
+            param = ban[1] || ''; // Change the param to 'ban' or 'unban' 
+            username = ban[2]; // The username to ban
         }
 
         switch (param) {

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -44,7 +44,16 @@ export class Themer {
         if (command !== '!theme') {
             return;
         }
+        
         param = param.toLowerCase().trim();
+
+        let username: string  | undefined;
+        /** Determine if the param is a (un)ban request */
+        const ban = param.match(/(?<subcommand>(?:un)?ban) (?<username>(\w)*)/);
+        if (ban) {
+            param = ban.groups && ban.groups.subcommand || '';
+            username = ban.groups && ban.groups.username;
+        }
 
         switch (param) {
             case '':
@@ -62,9 +71,62 @@ export class Themer {
             case 'refresh':
                 await this.refreshThemes(twitchUser);
                 break;
+            case 'ban':
+                await this.ban(twitchUser, username);
+                break;
+            case 'unban':
+                await this.unban(twitchUser, username);
+                break;
             default:
                 this.changeTheme(twitchUser, param);
                 break;
+        }
+    }
+
+    /**
+     * Retrieves an IListRecipient
+     * @param twitchUser The user to retrieve from the list of recipients
+     * @param banned (optional) Include only recipients that are banned
+     */
+    private getRecipient(twitchUser: string, banned?: boolean): IListRecipient | undefined {
+        return this._listRecipients.filter(f => f.username.toLowerCase() === twitchUser.toLowerCase() && f.banned === banned)[0];
+    }
+
+    /**
+     * Bans a user from using the themer plugin.
+     * @param twitchUser The user requesting the ban
+     * @param username The user to ban
+     */
+    private async ban(twitchUser: string | undefined, username: string | undefined) {
+        if (twitchUser !== undefined && 
+            twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase() &&
+            username !== undefined)  {
+            const recipient = this.getRecipient(username);
+            if (recipient === undefined) {
+                this._listRecipients.push({username: username.toLowerCase(), banned: true});
+                console.log(`${username} has been banned from using the themer plugin.`)
+                // TODO: Add banned user to a json file.
+            }
+        }
+    }
+
+    /**
+     * Unbans a user allowing them to use the themer plugin.
+     * @param twitchUser The user requesting the unban
+     * @param username The user to unban
+     */
+    private async unban(twitchUser: string | undefined, username: string | undefined) {
+        if (twitchUser !== undefined && 
+            twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase() && 
+            username !== undefined) {
+            const recipient = this.getRecipient(username, true);
+            if (recipient !== undefined) {
+                const index = this._listRecipients.indexOf(recipient);
+                recipient.banned = false;
+                this._listRecipients.splice(index, 1, recipient);
+                console.log(`${username} can now use the themer plugin.`)
+                // TODO: Remove banned user from a json file.
+            }
         }
     }
 
@@ -75,9 +137,14 @@ export class Themer {
     private async sendThemes(twitchUser: string | undefined) {
         if (twitchUser !== undefined) {
             /** Ensure that we haven't sent them the list recently. */
-            const lastSent: IListRecipient | undefined = this._listRecipients.filter(f => f.username.toLowerCase() === twitchUser.toLowerCase())[0];
+            const lastSent = this.getRecipient(twitchUser);
 
-            if (lastSent) {
+            if (lastSent && lastSent.banned && lastSent.banned === true) {
+                console.log(`${twitchUser} has been banned.`);
+                return;
+            }
+
+            if (lastSent && lastSent.lastSent) {
                 if (lastSent.lastSent.getDate() > ((new Date()).getDate() + -1)) {
                     return;
                 } else {
@@ -154,6 +221,16 @@ export class Themer {
      * @param themeName - Name of the theme to be applied
      */
     private async changeTheme(twitchUser: string | undefined, themeName: string) {
+        
+        /** Ensure the user hasn't been banned before changing the theme */
+        if (twitchUser) {
+            const recipient = this.getRecipient(twitchUser, true);
+            if (recipient && recipient.banned && recipient.banned === true) {
+                console.log(`${twitchUser} has been banned.`);
+                return;
+            }
+        }
+
         /** Find theme based on themeName and change theme if it is found */
         const theme = this._availableThemes.filter(f => f.label.toLowerCase() === themeName.toLowerCase())[0];
 


### PR DESCRIPTION
# Purpose

Sometimes things can get outta hand and we may need to moderate. As suggested in issue #4, we now have a `ban` and `unban` command that will prevent a user from using the `!theme` command.

# Changed files
- **IListRecipient** I added a `banned` property to track whether a user has been banned.
- **Themer** First I refactored the retrieval of recipients into its own function `getRecipients` which will retrieve users who match a given username and also, optionally, only return the user if the user has been banned (used for the `unban` function). I added two new functions: `ban` and `unban` to handle those subcommands (only the broadcaster may ban and un-ban at the moment). Finally I added logic to skip the changing of themes or requesting of the themes list if the user has been banned.

![e9696281-1b66-4454-8987-105f2ce8da08-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1](https://user-images.githubusercontent.com/8602418/57567010-cb4b4e00-7387-11e9-9016-8d5a31ef166d.png)