### PR TITLE
Save the current state of the banned list

### DIFF
--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -1,3 +1,4 @@
+import { Memento } from 'vscode';
 import { Client, Options, Userstate } from 'tmi.js';
 import { Themer } from '../commands/Themer';
 import { disconnect } from 'cluster';
@@ -19,10 +20,14 @@ export default class ChatClient {
     /** Event that fires when the connection status of the chat client changes */
     public onStatusChanged = this.chatClientStatusEventEmitter.event;
 
-    constructor() {
+    /**
+     * constructor
+     * @param state - The global state of the extension
+     */
+    constructor(state: Memento) {
         this._client = null;
         this._options = null;
-        this._themer = new Themer(this);
+        this._themer = new Themer(this, state);
     }
 
     /**

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -17,8 +17,9 @@ export class Themer {
     /**
      * constructor
      * @param _chatClient - Twitch chat client used in sending messages to users/chat
+     * @param _state - The global state of the extension
      */
-    constructor(private _chatClient: ChatClient) 
+    constructor(private _chatClient: ChatClient, private _state: vscode.Memento) 
     {
         /** 
          * Get the current theme so we can reset it later 
@@ -30,6 +31,11 @@ export class Themer {
          * Initialize the list of available themes for users
          */
         this.refreshThemes(Constants.chatClientUserName);
+
+        /**
+         * Rehydrate the banned users from the extensions global state
+         */
+        this._state.get('bannedUsers', []).forEach(username => this._listRecipients.push({ username, banned: true }));
     }
 
     /**
@@ -105,7 +111,7 @@ export class Themer {
             if (recipient === undefined) {
                 this._listRecipients.push({username: username.toLowerCase(), banned: true});
                 console.log(`${username} has been banned from using the themer plugin.`)
-                // TODO: Add banned user to a json file.
+                this._state.update('bannedUsers', this._listRecipients.map(recipient => recipient.username));
             }
         }
     }
@@ -125,7 +131,7 @@ export class Themer {
                 recipient.banned = false;
                 this._listRecipients.splice(index, 1, recipient);
                 console.log(`${username} can now use the themer plugin.`)
-                // TODO: Remove banned user from a json file.
+                this._state.update('bannedUsers', this._listRecipients.map(recipient => recipient.username));
             }
         }
     }

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -99,6 +99,17 @@ export class Themer {
     }
 
     /**
+     * Updates the state of the extension
+     */
+    private updateState() {
+        const bannedUsers = this._listRecipients
+            .filter(recipient => recipient.banned && recipient.banned === true)
+            .map(recipient => recipient.username);
+
+        this._state.update('bannedUsers', bannedUsers);
+    }
+
+    /**
      * Bans a user from using the themer plugin.
      * @param twitchUser The user requesting the ban
      * @param username The user to ban
@@ -111,7 +122,7 @@ export class Themer {
             if (recipient === undefined) {
                 this._listRecipients.push({username: username.toLowerCase(), banned: true});
                 console.log(`${username} has been banned from using the themer plugin.`)
-                this._state.update('bannedUsers', this._listRecipients.map(recipient => recipient.username));
+                this.updateState();
             }
         }
     }
@@ -130,8 +141,8 @@ export class Themer {
                 const index = this._listRecipients.indexOf(recipient);
                 recipient.banned = false;
                 this._listRecipients.splice(index, 1, recipient);
-                console.log(`${username} can now use the themer plugin.`)
-                this._state.update('bannedUsers', this._listRecipients.map(recipient => recipient.username));
+                console.log(`${username} can now use the themer plugin.`);
+                this.updateState();
             }
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { AuthenticationService } from './Authentication';
 import { Constants } from './Constants';
 import { createStatusBarItem } from './StatusBar';
 
-const chatClient = new ChatClient();
+let chatClient: ChatClient;
 const authService = new AuthenticationService();
 
 /**
@@ -23,10 +23,11 @@ authService.onAuthStatusChanged(async (status) => {
 	 */
 	if (status === TwitchClientStatus.loggedIn) {
 		const user = await authService.currentUser();
+		Constants.chatClientUserName = user.login;
 		if (user && user.accessToken) {
 			const opts = {
 				identity: {
-					username: Constants.chatClientUserName,
+					username: user.login,
 					password: user.accessToken,
 				},
 				channels: [user.login]
@@ -50,6 +51,10 @@ authService.onAuthStatusChanged(async (status) => {
  */
 export async function activate(context: vscode.ExtensionContext) {
 	console.log('Congratulations, Twitch Themer is now active!');
+
+	// We instantiate a new ChatClient using the global state of this extension;
+	// the state holds extension specific values such as the banned users.
+	chatClient = new ChatClient(context.globalState);
 
 	await authService.initialize();
 


### PR DESCRIPTION
# Purpose

It would be helpful if the banned list would persist between vscode sessions. So, this will save the state of the banned users into this extension's global state.

# Changed Files
- **ChatClient.ts** Included a parameter to pass the global state object to the Themer class.
- **Themer.ts** Added the logic needed to add/remove the banned users to/from the global state of the extension.
- **extension.ts** Refactored the ChatClient to be instantiated from within the activate function in order to pass parameters only available when vscode activates the extension (the globalState object).

![bitmoji](https://render.bitstrips.com/v2/cpanel/4cca87d1-95c0-4e8a-a110-92baa8293c26-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)