### PR TITLE
Follower Only Mode Command. Closes #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Broadcaster can use `!theme follower only` or `!theme follower only off` to activate or deactivate follower only mode
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ These commands will either ban or unban a user from changing the theme via Twitc
 ```
 `Note: List of banned users will reset on extension activation/start up.`
 
+#### Follower Only mode
+
+These commands will either activate or deactivate follower only mode.
+
+```
+!theme follower only
+
+!theme follower only off
+```
+`Note: Follower only mode will be turned off on extension activation/start up`
+
 
 ## How to connect to Twitch
 

--- a/src/Authentication.ts
+++ b/src/Authentication.ts
@@ -124,6 +124,20 @@ export class AuthenticationService {
         return false;
     }
 
+    public async getFollowers() {
+        if (keytar) {
+            var accessToken = await keytar.getPassword(service, account);
+            if (accessToken) {
+                const currentUser = await this.currentUser();
+                const url = `https://api.twitch.tv/helix/users/follows?to_id=${currentUser.id}`;
+                const res = await fetch.default(url, { headers: { 'Authorization': `Bearer ${accessToken}` } });
+                const json = await res.json();
+                return json.data;
+            }
+        }
+        return [];
+    }
+
     private async getUserDetails(token: string | null) {
         const url = 'https://api.twitch.tv/helix/users';
         const res = await fetch.default(url, { headers: { 'Authorization': `Bearer ${token}` } });

--- a/src/Authentication.ts
+++ b/src/Authentication.ts
@@ -107,6 +107,23 @@ export class AuthenticationService {
         return null;
     }
 
+    public async twitchUser(twitchUserId: string | undefined) {
+        if (twitchUserId) {
+            if (keytar) {
+                var accessToken = await keytar.getPassword(service, account);
+                if (accessToken) {
+                    const currentUser = await this.currentUser();
+                    const url = `https://api.twitch.tv/helix/users/follows?from_id=${twitchUserId}&to_id=${currentUser.id}`;
+                    const res = await fetch.default(url, { headers: { 'Authorization': `Bearer ${accessToken}` } });
+                    const json = await res.json();
+                    return (json.data.length > 0) ? true: false;
+                }
+            }
+        }
+        console.log('no twitchUserId was passed in.');
+        return false;
+    }
+
     private async getUserDetails(token: string | null) {
         const url = 'https://api.twitch.tv/helix/users';
         const res = await fetch.default(url, { headers: { 'Authorization': `Bearer ${token}` } });

--- a/src/Authentication.ts
+++ b/src/Authentication.ts
@@ -107,7 +107,7 @@ export class AuthenticationService {
         return null;
     }
 
-    public async twitchUser(twitchUserId: string | undefined) {
+    public async isTwitchUserFollowing(twitchUserId: string | undefined) {
         if (twitchUserId) {
             if (keytar) {
                 var accessToken = await keytar.getPassword(service, account);

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -68,8 +68,8 @@ export default class ChatClient {
          * continue working without having to manually change their
          * theme back to their preferred theme.
          */
-        // TODO: Figure out a way to resetTheme 
-        // await this._themer.resetTheme(undefined);
+        this._themer.followerOnly(Constants.chatClientUserName, false);
+        await this._themer.resetTheme(undefined);
     }
 
     /** Is the client currently connected to Twitch chat */

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -123,13 +123,6 @@ export default class ChatClient {
         if (!message) { return; }
 
         if (message.toLocaleLowerCase().startsWith('!theme')) {
-            // let userFollowing : boolean = false;
-            // if (userState["display-name"] === Constants.chatClientUserName) {
-            //     // broadcaster cannot follow their own stream. Temporary work around to mark broadcaster as follower.
-            //     userFollowing = true;
-            // } else {
-            //     userFollowing = await this._authenticationService.isTwitchUserFollowing(userState["user-id"]);
-            // }
             await this._themer.handleCommands(userState, '!theme', message.replace('!theme', '').trim());
         }
     }

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -5,14 +5,12 @@ import { disconnect } from 'cluster';
 import { EventEmitter } from 'vscode';
 import { TwitchClientStatus } from '../Enum';
 import { Constants } from '../Constants';
-import { AuthenticationService } from '../Authentication';
 
 /**
  * Twitch chat client used in communicating via chat/whispers
  */
 export default class ChatClient {
 
-    private _authenticationService : AuthenticationService;
     private _client: Client | null;
     private _options: Options | null;
     private readonly _themer: Themer;
@@ -27,7 +25,6 @@ export default class ChatClient {
      * @param state - The global state of the extension
      */
     constructor(state: Memento) {
-        this._authenticationService = new AuthenticationService;
         this._client = null;
         this._options = null;
         this._themer = new Themer(this, state);
@@ -71,7 +68,8 @@ export default class ChatClient {
          * continue working without having to manually change their
          * theme back to their preferred theme.
          */
-        await this._themer.resetTheme(true);
+        // TODO: Figure out a way to resetTheme 
+        // await this._themer.resetTheme(undefined);
     }
 
     /** Is the client currently connected to Twitch chat */
@@ -125,14 +123,14 @@ export default class ChatClient {
         if (!message) { return; }
 
         if (message.toLocaleLowerCase().startsWith('!theme')) {
-            let userFollowing : boolean = false;
-            if (userState["display-name"] === Constants.chatClientUserName) {
-                // broadcaster cannot follow their own stream. Temporary work around to mark broadcaster as follower.
-                userFollowing = true;
-            } else {
-                userFollowing = await this._authenticationService.isTwitchUserFollowing(userState["user-id"]);
-            }
-            await this._themer.handleCommands(userState["display-name"], '!theme', message.replace('!theme', '').trim(), userFollowing);
+            // let userFollowing : boolean = false;
+            // if (userState["display-name"] === Constants.chatClientUserName) {
+            //     // broadcaster cannot follow their own stream. Temporary work around to mark broadcaster as follower.
+            //     userFollowing = true;
+            // } else {
+            //     userFollowing = await this._authenticationService.isTwitchUserFollowing(userState["user-id"]);
+            // }
+            await this._themer.handleCommands(userState, '!theme', message.replace('!theme', '').trim());
         }
     }
 }

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -130,7 +130,7 @@ export default class ChatClient {
                 // broadcaster cannot follow their own stream. Temporary work around to mark broadcaster as follower.
                 userFollowing = true;
             } else {
-                userFollowing = await this._authenticationService.twitchUser(userState["user-id"]);
+                userFollowing = await this._authenticationService.isTwitchUserFollowing(userState["user-id"]);
             }
             await this._themer.handleCommands(userState["display-name"], '!theme', message.replace('!theme', '').trim(), userFollowing);
         }

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -125,7 +125,13 @@ export default class ChatClient {
         if (!message) { return; }
 
         if (message.toLocaleLowerCase().startsWith('!theme')) {
-            const userFollowing : boolean = await this._authenticationService.twitchUser(userState["user-id"]);
+            let userFollowing : boolean = false;
+            if (userState["display-name"] === Constants.chatClientUserName) {
+                // broadcaster cannot follow their own stream. Temporary work around to mark broadcaster as follower.
+                userFollowing = true;
+            } else {
+                userFollowing = await this._authenticationService.twitchUser(userState["user-id"]);
+            }
             await this._themer.handleCommands(userState["display-name"], '!theme', message.replace('!theme', '').trim(), userFollowing);
         }
     }

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -85,12 +85,12 @@ export class Themer {
             case 'unban':
                 await this.unban(twitchUser, username);
                 break;
-            // case 'follower only':
-            //     await this.followerOnly(twitchUser, true);
-            //     break;
-            // case 'follower only off':
-            //     await this.followerOnly(twitchUser, false);
-            //     break;
+            case 'follower only':
+                await this.followerOnly(twitchUser, true);
+                break;
+            case 'follower only off':
+                await this.followerOnly(twitchUser, false);
+                break;
             default:
                 this.changeTheme(twitchUser, param, following);
                 break;
@@ -155,19 +155,19 @@ export class Themer {
         }
     }
     
-    // /**
-    //  * Activates follower only mode
-    //  * @param twitchUser - The user requesting the follower mode change
-    //  * @param activate - Set follower only mode
-    //  */
-    // private async followerOnly(twitchUser: string | undefined, activate: boolean)
-    // {
-    //     if (twitchUser !== undefined && 
-    //     twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
-    //         this._followerOnly = activate;
-    //         this._followerOnly ? console.log('Follower Only mode has been activated.') : console.log('Follower Only mode has been deactivated.');
-    //     }
-    // }
+    /**
+     * Activates follower only mode
+     * @param twitchUser - The user requesting the follower mode change
+     * @param activate - Set follower only mode
+     */
+    private async followerOnly(twitchUser: string | undefined, activate: boolean)
+    {
+        if (twitchUser !== undefined && 
+        twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
+            this._followerOnly = activate;
+            this._followerOnly ? console.log('Follower Only mode has been activated.') : console.log('Follower Only mode has been deactivated.');
+        }
+    }
 
     /**
      * Send a whisper to the requesting user with a list of available themes


### PR DESCRIPTION
### Purpose
Sometimes things can get outta hand and we may need to moderate. As suggested in issue #2, we now have a follower only command that will allow only followers to change the theme. 

### Changed files
**Authentication.ts** 
* Added a twitch API call to check if the twitch user is following the streamer. The call to the API is required as the UserState object in tmi.js does not indicate if a user is following or not
* Added a twitch API call to get all followers of the streamer

**ChatClient.ts**
* Update disconnect to deactivate follower only mode before trying to reset the theme
* Update onMessageHandler to pass through complete userState

**Themer.ts** 
* Added commands to activate and deactivate follower only mode
* When follower only mode is activated, get new list of followers
* Update commands, which can change the theme, to pass through the userState
* Update changeTheme to handle allowing a theme to be updated if the user is following

_Edited to explain more changes to files_ 