### PR TITLE
Stub out getFollowers to fix issues with build servers

### DIFF
--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -24,7 +24,7 @@ export class Themer {
      * @param _chatClient - Twitch chat client used in sending messages to users/chat
      * @param _state - The global state of the extension
      */
-    constructor(private _chatClient: ChatClient, private _state: vscode.Memento) 
+    constructor(private _chatClient: ChatClient, private _state: vscode.Memento, authService = new AuthenticationService) 
     {
         /** 
          * Get the current theme so we can reset it later 
@@ -50,7 +50,7 @@ export class Themer {
         /**
          * Create a connection to the authenication service
          */
-        this._authService = new AuthenticationService;
+        this._authService = authService;
     }
 
     /**

--- a/src/test/themer.test.ts
+++ b/src/test/themer.test.ts
@@ -8,6 +8,7 @@ import ChatClient from '../chat/ChatClient';
 import { Themer } from '../commands/Themer';
 import { Constants } from '../Constants';
 import { Userstate } from 'tmi.js';
+import { AuthenticationService } from '../Authentication';
 
 chai.should();
 
@@ -228,23 +229,31 @@ suite('Themer Tests', function () {
       });
   });
 
-  // test('Themer should go to follower only mode if user is the logged in user', function(done) {
-  //   const twitchUser: Userstate = { 'display-name': Constants.chatClientUserName };
+  test('Themer should go to follower only mode if user is the logged in user', function(done) {
+    const twitchUser: Userstate = { 'display-name': Constants.chatClientUserName };
+    const fakeAuthService: AuthenticationService = new AuthenticationService;
 
-  //   fakeState.update('followerOnly', false);
-  //   fakeThemer = new Themer(fakeChatClient, fakeState);
+    // We stub out the getFollowers function to return an empty array.
+    // The getFollowers() method requires access to 'keytar' which
+    // isn't available in the Linux build servers as 'keytar' depends
+    // on Gnome libraries which aren't installed because no GUI is
+    // installed on the Linux build servers.
+    sinon.stub(fakeAuthService, 'getFollowers').returns(Promise.resolve([]));
 
-  //   fakeThemer.handleCommands(twitchUser, '!theme', `follower`)
-  //     .then(() => {
-  //       try {
-  //         fakeState.get('followerOnly')!.should.be.true;
-  //         done();
-  //       }
-  //       catch (error) {
-  //         done(error);
-  //       }
-  //   });
-  // });
+    fakeState.update('followerOnly', false);
+    fakeThemer = new Themer(fakeChatClient, fakeState, fakeAuthService);
+
+    fakeThemer.handleCommands(twitchUser, '!theme', `follower`)
+      .then(() => {
+        try {
+          fakeState.get('followerOnly')!.should.be.true;
+          done();
+        }
+        catch (error) {
+          done(error);
+        }
+    });
+  });
 
   test('Themer should not go to follower only mode if user is not the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': 'goofey' };


### PR DESCRIPTION
# Purpose

This PR solves an issue with the tests failing on our Linux build servers.

# The Issue

The Linux build server would fail when running one of our tests: https://github.com/MichaelJolley/vscode-twitch-themer/blob/968ca67412be53054f5152098fb7874ccd1f7961/src/test/themer.test.ts#L231-L247 I narrowed the issue down to the Themer class calling a method in the AuthenticationService class which relies on 'keytar' which is not available on the Linux build servers; 'keytar' is a node module that has a prerequisite on a Gnome module that isn't available because no GUI exists.

# The Fix

I stubbed out the AuthenticationService' getFollowers() method to return an empty array.

# Changed Files

- **themer.ts** I added an option to override the AuthenticationService in the constructor so our test can insert it's stubbed version.
- **themer.tests.ts** I added the logic necessary in the failing test to stub out the AuthenticationService' getFollowers method to return an empty array.

![](https://render.bitstrips.com/v2/cpanel/e4f91d37-026a-44d0-91ea-b26cfdaa34a7-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1)