### PR TITLE
fix theme name usage to actually display the theme name in chat

### DIFF
--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -375,7 +375,7 @@ export class Themer {
                 });
             }
         }else{
-            this._chatClient.sendMessage(`${twitchUserName}, ${theme} is not a valid theme name or isn't installed.  You can use !theme list to get a list of available themes.`);
+            this._chatClient.sendMessage(`${twitchUserName}, ${themeName} is not a valid theme name or isn't installed.  You can use !theme list to get a list of available themes.`);
         }
     }
 


### PR DESCRIPTION
The variable "theme" is undefined, so all messages respond with "<name>, undefined is not a valid theme name or isn't installed. You can use !theme list to get a list of available themes."

This fix will make sure to use the correct variable here.