### PR TITLE
Store both the Follow Only and Subscriber Only settings in VSCode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1925,8 +1925,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1947,14 +1946,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1969,20 +1966,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2099,8 +2093,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2112,7 +2105,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2127,7 +2119,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2135,14 +2126,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2161,7 +2150,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2242,8 +2230,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2255,7 +2242,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2341,8 +2327,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2378,7 +2363,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2398,7 +2382,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2442,14 +2425,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -61,7 +61,18 @@
 		],
 		"configuration": {
 			"title": "Twitch Themer",
-			"properties": {}
+			"properties": {
+				"twitchThemer.followerOnly": {
+					"type": "boolean",
+					"default": false,
+					"description": "Follow Only mode"
+				},
+				"typescript.subscriberOnly": {
+					"type": "boolean",
+					"default": false,
+					"description": "Subscriber only mode"
+				}
+			}
 		}
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 					"default": false,
 					"description": "Follow Only mode"
 				},
-				"typescript.subscriberOnly": {
+				"twitchThemer.subscriberOnly": {
 					"type": "boolean",
 					"default": false,
 					"description": "Subscriber only mode"

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -30,11 +30,19 @@ export default class ChatClient {
         this._options = null;
         this._themer = new Themer(this, state);
     }
-
-    public changeFollowerOnlyMode(followerOnly: boolean){
+    /**
+     * Changes Follower only flag 
+     * @param followerOnly 
+     */
+    public toggleFollowerOnlyMode(followerOnly: boolean){
         this._themer.followerOnly(Constants.chatClientUserName, followerOnly);
     }
-    public changeSubscriberOnlyMode(subscriberOnly: boolean){
+
+    /**
+     * Changes Subscriber only flag 
+     * @param subscriberOnly 
+     */
+    public toggleSubscriberOnlyMode(subscriberOnly: boolean){
         this._themer.subOnly(Constants.chatClientUserName, subscriberOnly);
     }
 

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -31,6 +31,13 @@ export default class ChatClient {
         this._themer = new Themer(this, state);
     }
 
+    public changeFollowerOnlyMode(followerOnly: boolean){
+        this._themer.followerOnly(Constants.chatClientUserName, followerOnly);
+    }
+    public changeSubscriberOnlyMode(subscriberOnly: boolean){
+        this._themer.subOnly(Constants.chatClientUserName, subscriberOnly);
+    }
+
     /**
      * Connects to Twitch chat
      * @param options - tmi.js Options for connecting to Twitch chat 

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -17,7 +17,6 @@ export default class ChatClient {
 
     private chatClientStatusEventEmitter = new EventEmitter<TwitchClientStatus>();
 
-
     /** Event that fires when the connection status of the chat client changes */
     public onStatusChanged = this.chatClientStatusEventEmitter.event;
 

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -17,6 +17,7 @@ export default class ChatClient {
 
     private chatClientStatusEventEmitter = new EventEmitter<TwitchClientStatus>();
 
+
     /** Event that fires when the connection status of the chat client changes */
     public onStatusChanged = this.chatClientStatusEventEmitter.event;
 

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -47,7 +47,7 @@ export class Themer {
         /**
          * Initialize sub only flag
          */
-        this._subOnly = this._state.get('subOnly', false);
+        this._subOnly = vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly', false);
 
         /**
          * Rehydrate the banned users from the extensions global state
@@ -144,7 +144,6 @@ export class Themer {
             .map(recipient => recipient.username);
 
         this._state.update('bannedUsers', bannedUsers);
-        this._state.update('subOnly', this._subOnly);
     }
 
     /**
@@ -213,13 +212,14 @@ export class Themer {
      * @param twitchUser - The user requesting the follower mode change
      * @param activate - Set follower only mode
      */
-    private async subOnly(twitchUser: string | undefined, activate: boolean)
+    public async subOnly(twitchUser: string | undefined, activate: boolean)
     {
         if (twitchUser !== undefined && 
         twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
             this._subOnly = activate;
-            this.updateState();
-            this._subOnly ? console.log('Sub Only mode has been activated.') : console.log('Sub Only mode has been deactivated.');
+            const message = this._subOnly ? 'Sub Only mode has been activated' : 'Sub Only mode has been deactivated.';
+            console.log(message);
+            this._chatClient.sendMessage(message);        
         }
     }
 

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -216,7 +216,7 @@ export class Themer {
     {
         if (twitchUser !== undefined && 
         twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
-            this._subOnly = activate;
+            vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', activate);
             const message = this._subOnly ? 'Sub Only mode has been activated' : 'Sub Only mode has been deactivated.';
             console.log(message);
             this._chatClient.sendMessage(message);        

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -194,6 +194,7 @@ export class Themer {
         if (twitchUser !== undefined && 
             twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
             vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', activate);
+            this._followerOnly = activate;
             if (activate)
             {
                 this._followers = [];
@@ -217,7 +218,8 @@ export class Themer {
         if (twitchUser !== undefined && 
         twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
             vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', activate);
-            const message = this._subOnly ? 'Sub Only mode has been activated' : 'Sub Only mode has been deactivated.';
+            this._subOnly = activate;
+            const message = vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly', false) ? 'Sub Only mode has been activated' : 'Sub Only mode has been deactivated.';
             console.log(message);
             this._chatClient.sendMessage(message);        
         }

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -5,6 +5,7 @@ import { IListRecipient } from './IListRecipient';
 import { Constants } from '../Constants';
 import { Userstate } from 'tmi.js';
 import { AuthenticationService } from '../Authentication';
+import { watch } from 'fs';
 
 /**
  * Manages all logic associated with retrieveing themes,
@@ -41,7 +42,7 @@ export class Themer {
         /**
          * Initialize follower only flag
          */
-        this._followerOnly = this._state.get('followerOnly', false);
+        this._followerOnly = vscode.workspace.getConfiguration().get('twitchThemer.followerOnly', false);
 
         /**
          * Initialize sub only flag
@@ -57,6 +58,7 @@ export class Themer {
          * Create a connection to the authenication service
          */
         this._authService = authService;
+        
     }
 
     /**
@@ -142,7 +144,6 @@ export class Themer {
             .map(recipient => recipient.username);
 
         this._state.update('bannedUsers', bannedUsers);
-        this._state.update('followerOnly', this._followerOnly);
         this._state.update('subOnly', this._subOnly);
     }
 
@@ -193,15 +194,15 @@ export class Themer {
     {
         if (twitchUser !== undefined && 
             twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
-            this._followerOnly = activate;
-            if (this._followerOnly)
+            vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', activate);
+            if (activate)
             {
                 this._followers = [];
                 const followers : Array<any> = await this._authService.getFollowers();
                 followers.forEach(x => this._followers.push({username: x["from_name"].toLocaleLowerCase()}));
             }
             this.updateState();
-            const message = this._followerOnly ? 'Follower Only mode has been activated.' :'Follower Only mode has been deactivated.';
+            const message = vscode.workspace.getConfiguration().get('twitchThemer.followerOnly', false) ? 'Follower Only mode has been activated.' :'Follower Only mode has been deactivated.';
             console.log(message);
             this._chatClient.sendMessage(message);        
         }

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -5,7 +5,6 @@ import { IListRecipient } from './IListRecipient';
 import { Constants } from '../Constants';
 import { Userstate } from 'tmi.js';
 import { AuthenticationService } from '../Authentication';
-import { watch } from 'fs';
 
 /**
  * Manages all logic associated with retrieveing themes,
@@ -58,7 +57,6 @@ export class Themer {
          * Create a connection to the authenication service
          */
         this._authService = authService;
-        
     }
 
     /**
@@ -195,14 +193,14 @@ export class Themer {
             twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
             vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', activate);
             this._followerOnly = activate;
-            if (activate)
+            if (this._followerOnly)
             {
                 this._followers = [];
                 const followers : Array<any> = await this._authService.getFollowers();
                 followers.forEach(x => this._followers.push({username: x["from_name"].toLocaleLowerCase()}));
             }
             this.updateState();
-            const message = vscode.workspace.getConfiguration().get('twitchThemer.followerOnly', false) ? 'Follower Only mode has been activated.' :'Follower Only mode has been deactivated.';
+            const message = this._followerOnly ? 'Follower Only mode has been activated.' :'Follower Only mode has been deactivated.';
             console.log(message);
             this._chatClient.sendMessage(message);        
         }
@@ -219,7 +217,7 @@ export class Themer {
         twitchUser.toLowerCase() === Constants.chatClientUserName.toLowerCase()) {
             vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', activate);
             this._subOnly = activate;
-            const message = vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly', false) ? 'Sub Only mode has been activated' : 'Sub Only mode has been deactivated.';
+            const message = this._subOnly ? 'Sub Only mode has been activated' : 'Sub Only mode has been deactivated.';
             console.log(message);
             this._chatClient.sendMessage(message);        
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,12 +65,15 @@ export async function activate(context: vscode.ExtensionContext) {
 	const chatDisconnectCommand = vscode.commands.registerCommand(Commands.chatDisconnect, chatClient.disconnect.bind(chatClient));
 	
 
-	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent)=>{
+	const handleSettingsChange = vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent)=>{
 		if(e.affectsConfiguration('twitchThemer.followerOnly')){
-			console.log("CHANGED!");
+			chatClient.changeFollowerOnlyMode(vscode.workspace.getConfiguration().get('twitchThemer.followerOnly', false));
 		}
-	}))
-	context.subscriptions.push(chatConnectCommand, chatDisconnectCommand, signInCommand, signOutCommand, statusBarItem);
+		if(e.affectsConfiguration('twitchThemer.subscriberOnly')){
+			chatClient.changeSubscriberOnlyMode(vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly', false));
+		}
+	});
+	context.subscriptions.push(chatConnectCommand, chatDisconnectCommand, signInCommand, signOutCommand, statusBarItem, handleSettingsChange);
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,16 +63,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	const signOutCommand = vscode.commands.registerCommand(Commands.twitchSignOut, authService.handleSignOut.bind(authService));
 	const chatConnectCommand = vscode.commands.registerCommand(Commands.chatConnect, authService.handleSignIn.bind(authService));
 	const chatDisconnectCommand = vscode.commands.registerCommand(Commands.chatDisconnect, chatClient.disconnect.bind(chatClient));
-	
 
 	const handleSettingsChange = vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent)=>{
 		if(e.affectsConfiguration('twitchThemer.followerOnly')){
-			chatClient.changeFollowerOnlyMode(vscode.workspace.getConfiguration().get('twitchThemer.followerOnly', false));
+			chatClient.toggleFollowerOnlyMode(vscode.workspace.getConfiguration().get('twitchThemer.followerOnly', false));
 		}
 		if(e.affectsConfiguration('twitchThemer.subscriberOnly')){
-			chatClient.changeSubscriberOnlyMode(vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly', false));
+			chatClient.toggleSubscriberOnlyMode(vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly', false));
 		}
 	});
+	
 	context.subscriptions.push(chatConnectCommand, chatDisconnectCommand, signInCommand, signOutCommand, statusBarItem, handleSettingsChange);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	const signOutCommand = vscode.commands.registerCommand(Commands.twitchSignOut, authService.handleSignOut.bind(authService));
 	const chatConnectCommand = vscode.commands.registerCommand(Commands.chatConnect, authService.handleSignIn.bind(authService));
 	const chatDisconnectCommand = vscode.commands.registerCommand(Commands.chatDisconnect, chatClient.disconnect.bind(chatClient));
+	
 
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent)=>{
+		if(e.affectsConfiguration('twitchThemer.followerOnly')){
+			console.log("CHANGED!");
+		}
+	}))
 	context.subscriptions.push(chatConnectCommand, chatDisconnectCommand, signInCommand, signOutCommand, statusBarItem);
 }
 

--- a/src/test/themer.test.ts
+++ b/src/test/themer.test.ts
@@ -242,13 +242,13 @@ suite('Themer Tests', function () {
     // installed on the Linux build servers.
     sinon.stub(fakeAuthService, 'getFollowers').returns(Promise.resolve([]));
 
-    fakeState.update('followerOnly', false);
+    vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', false);
     fakeThemer = new Themer(fakeChatClient, fakeState, fakeAuthService);
 
     fakeThemer.handleCommands(twitchUser, '!theme', `follower`)
       .then(() => {
         try {
-          fakeState.get('followerOnly')!.should.be.true;
+          vscode.workspace.getConfiguration().get('twitchThemer.followerOnly')!.should.be.true;
           done();
         }
         catch (error) {
@@ -260,12 +260,12 @@ suite('Themer Tests', function () {
   test('Themer should not go to follower only mode if user is not the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': 'goofey' };
 
-    fakeState.update('followerOnly', false);
+    vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', false);
 
     fakeThemer.handleCommands(twitchUser, '!theme', `follower`)
       .then(() => {
         try {
-          fakeState.get('followerOnly')!.should.be.false;
+          vscode.workspace.getConfiguration().get('twitchThemer.followerOnly')!.should.be.false;
           done();
         }
         catch (error) {
@@ -277,12 +277,12 @@ suite('Themer Tests', function () {
   test('Themer should leave follower only mode if user is the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': Constants.chatClientUserName };
 
-    fakeState.update('followerOnly', true);
+    vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', true);
   
     fakeThemer.handleCommands(twitchUser, '!theme', `!follower`)
       .then(() => {
         try {
-          fakeState.get('followerOnly')!.should.be.false;
+          vscode.workspace.getConfiguration().get('twitchThemer.followerOnly')!.should.be.false;
           done();
         }
         catch (error) {
@@ -294,12 +294,12 @@ suite('Themer Tests', function () {
   test('Themer should not leave follower only mode if user is not the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': 'goofey' };
 
-    fakeState.update('followerOnly', true);
+    vscode.workspace.getConfiguration().update('twitchThemer.followerOnly', true);
     
     fakeThemer.handleCommands(twitchUser, '!theme', `!follower`)
       .then(() => {
         try {
-          fakeState.get('followerOnly')!.should.be.true;
+          vscode.workspace.getConfiguration().get('twitchThemer.followerOnly')!.should.be.true;
           done();
         }
         catch (error) {
@@ -310,12 +310,12 @@ suite('Themer Tests', function () {
 
   test('Themer should go to subscriber only mode if user is the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': Constants.chatClientUserName };
-    fakeState.update('subOnly', false);
+    vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', false);
 
     fakeThemer.handleCommands(twitchUser, '!theme', `sub`)
       .then(() => {
         try {
-          fakeState.get('subOnly')!.should.be.true;
+          vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly')!.should.be.true;
           done();
         }
         catch (error) {
@@ -326,12 +326,12 @@ suite('Themer Tests', function () {
 
   test('Themer should not go to subscriber only mode if user is not the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': 'goofey' };
-    fakeState.update('subOnly', false);
+    vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', false);
 
     fakeThemer.handleCommands(twitchUser, '!theme', `sub`)
       .then(() => {
         try {
-          fakeState.get('subOnly')!.should.be.false;
+          vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly')!.should.be.false;
           done();
         }
         catch (error) {
@@ -342,12 +342,12 @@ suite('Themer Tests', function () {
   
   test('Themer should leave subscriber only mode if user is the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': Constants.chatClientUserName };
-    fakeState.update('subOnly', true);
+    vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', true);
   
     fakeThemer.handleCommands(twitchUser, '!theme', `!sub`)
       .then(() => {
         try {
-          fakeState.get('subOnly')!.should.be.false;
+          vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly')!.should.be.false;
           done();
         }
         catch (error) {
@@ -358,12 +358,12 @@ suite('Themer Tests', function () {
 
   test('Themer should not leave subscriber only mode if user is not the logged in user', function(done) {
     const twitchUser: Userstate = { 'display-name': 'goofey' };
-    fakeState.update('subOnly', true);
+    vscode.workspace.getConfiguration().update('twitchThemer.subscriberOnly', true);
     
     fakeThemer.handleCommands(twitchUser, '!theme', `!sub`)
       .then(() => {
         try {
-          fakeState.get('subOnly')!.should.be.true;
+          vscode.workspace.getConfiguration().get('twitchThemer.subscriberOnly')!.should.be.true;
           done();
         }
         catch (error) {


### PR DESCRIPTION
<img width="288" alt="Screen Shot 2019-05-24 at 8 08 58 PM" src="https://user-images.githubusercontent.com/6597539/58361957-2db04e00-7e60-11e9-83a9-90ffed082657.png">

Had to modify tests to match new format.
Added event handler to settings change.
Made sure to populate and change the settings values when toggled through chat commands.

First real TS work, feel free to rip apart :)

Closes #55 

