### PR TITLE
Azure Pipelines YAML refactoring + publish test results

### DIFF
--- a/azurepipelines.yaml
+++ b/azurepipelines.yaml
@@ -1,127 +1,90 @@
 jobs:
-- job: Linux
-  pool:
-    # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent
-    name: Hosted Ubuntu 1604
-    demands: npm
+- job: 'Build'  
   strategy:
     matrix:
-      node_8_x:
+      linux_node-8.x:
+        imageName: 'ubuntu-16.04'
         node_version: 8.x
-      node_10_x:
+      linux_node-10.x:
+        imageName: 'ubuntu-16.04'
         node_version: 10.x
-  steps:
-  - task: NodeTool@0
-    displayName: 'Use $(node_version)'
-    inputs:
-      versionSpec: $(node_version)
+      windows:
+        imageName: 'vs2017-win2016'
+        node_version: 10.x
+      macOS:
+        imageName: 'macos-10.13'
+        node_version: 10.x
 
-  - task: Npm@1
-    displayName: 'Install dependencies'
-    inputs:
-      verbose: false
-      command: install
-
-  - task: Npm@1
-    displayName: 'Compile TypeScript'
-    inputs:
-      command: custom
-      verbose: false
-      customCommand: 'run test-compile'
-    enabled: true
-
-  # starts a process that allows the vscode test environment to run
-  - script: |
-      set -e
-      /usr/bin/Xvfb :10 -ac >> /tmp/Xvfb.out 2>&1 &
-      disown -ar
-    displayName: 'Start xvfb'
-
-  - script: 'node node_modules/vscode/bin/test'
-    displayName: 'Run tests via npm script'
-    env:
-      DISPLAY: :10
-    enabled: true
-
-- job: Windows
   pool:
-    # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent
-    name: Hosted VS2017
-    demands: npm
+    vmImage: $(imageName)
+
+  steps:
+    - task: NodeTool@0
+      displayName: 'Use node $(node_version)'
+      inputs:
+        versionSpec: $(node_version)
+    - task: Npm@1
+      displayName: 'Install dependencies'
+      inputs:
+        command: install
+        verbose: false
+    - task: Npm@1
+      displayName: 'Compile TypeScript'
+      inputs:
+        command: custom
+        customCommand: 'run test-compile'
+        verbose: false
+    - task: Bash@3
+      displayName: 'Start xvfb if running Linux'
+      # Only run this task if the OS is linux
+      condition: eq(variables['Agent.OS'], 'Linux')
+      inputs:
+        verbose: false
+        targetType: 'inline'
+        script: |
+          set -e
+          /usr/bin/Xvfb :10 -ac >> /tmp/Xvfb.out 2>&1 &
+          disown -ar
+    - task: Bash@3
+      displayName: 'Run tests via vscode test script'
+      env:
+        DISPLAY: :10
+      inputs:
+        verbose: false
+        targetType: 'inline'
+        script: |
+          node node_modules/vscode/bin/test
+    - task: PublishTestResults@2  
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: '**/TEST-*.xml'
+        testRunTitle: '$(Agent.OS) (node: $(node_version))'
+
+- job: 'Publish'
+  displayName: 'Publish VSIX Package'
+  dependsOn: 'Build'
+  condition: succeeded()
+  
+  pool: 
+    vmImage: 'macOS-10.13'
+  
   steps:
   - task: NodeTool@0
-    displayName: 'Use Node 10.x'
+    displayName: 'Use node 10.x'
     inputs:
       versionSpec: 10.x
-
   - task: Npm@1
     displayName: 'Install dependencies'
     inputs:
-      verbose: false
       command: install
-
+      verbose: false
   - task: Npm@1
-    displayName: 'Compile TypeScript'
+    displayName: 'Create VSIX Package'
     inputs:
       command: custom
+      customCommand: 'run package'
       verbose: false
-      customCommand: 'run test-compile'
-    enabled: true
-
-  - task: Npm@1
-    displayName: 'Run tests via npm script'
-    inputs:
-      command: custom
-      verbose: false
-      customCommand: 'run just-test'
-    env:
-      DISPLAY: :10
-    enabled: true
-
-  - script: 'node node_modules/vscode/bin/test'
-    displayName: 'Run tests'
-    enabled: false
-    env:
-      DISPLAY: :10
-
-- job: macOS
-  pool:
-    # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent
-    name: Hosted macOS
-    demands: npm
-  steps:
-  - task: NodeTool@0
-    displayName: 'Use Node 10.x'
-    inputs:
-      versionSpec: 10.x
-
-  - task: Npm@1
-    displayName: 'Install dependencies'
-    inputs:
-      verbose: false
-      command: install
-
-  - task: Npm@1
-    displayName: 'Compile TypeScript'
-    inputs:
-      command: custom
-      verbose: false
-      customCommand: 'run test-compile'
-    enabled: true
-
-  - task: Npm@1
-    displayName: 'Run tests via npm script'
-    inputs:
-      command: custom
-      verbose: false
-      customCommand: 'run just-test'
-    enabled: true
-
-  - script: |
-      npx vsce package -o release.vsix
-    displayName: 'create vsix'
-
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Pipeline Artifact'
     inputs:
-      targetPath: release.vsix
+      targetPath: 'release.vsix'

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		}
 	},
 	"scripts": {
-		"package": "npx vsce package",
+		"package": "npx vsce package -o release.vsix",
 		"publish": "npx vsce publish",
 		"vscode:prepublish": "webpack --mode production",
 		"webpack": "webpack --mode none",


### PR DESCRIPTION
# Purpose

I thought we should publish our test results in Azure Pipelines but while working with the YAML I learned that the duplication of steps was unnecessary so I refactored the entire YAML as well.

# Changes
- `azurepipelines.yaml` - I completely refactored the YAML configuration in order to write our steps once, I used conditions to skip certain steps when needed (mainly the xvfb requirement for Linux). Additionally, I split the 'Build' jobs from the 'Publish' job. Publishing will only occur if the 'Build' jobs are successful and it uses the NPM `package` script in order to create the VSIX package.
- `package.json` - Needed to change the NPM script to output the correct package name (release.vsix) we use during our build steps.

![bitmoji](https://render.bitstrips.com/v2/cpanel/ec48e54c-1ede-452a-ba29-4d4f918ccf2a-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)

![image](https://user-images.githubusercontent.com/8602418/58391194-94ad3e80-7fe9-11e9-9b29-7c6187d2258f.png)
![image](https://user-images.githubusercontent.com/8602418/58389310-56f6e880-7fde-11e9-84bb-a2470304f7c8.png)
![image](https://user-images.githubusercontent.com/8602418/58391191-91b24e00-7fe9-11e9-8a7b-d8fc3e243d6a.png)

