### PR TITLE
New 'install' command to install themes! Closes #93

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,8 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
-			]
+			],
+			"preLaunchTask": "npm: webpack"
 		},
 		{
 			"name": "Extension Tests",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-twitch-themer",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/Enum.ts
+++ b/src/Enum.ts
@@ -76,3 +76,17 @@ export enum UserLevel {
   /** Broadcaster */
   broadcaster = 2
 }
+
+/**
+ * Represents the reasons why a theme isn't available
+ */
+export enum ThemeNotAvailableReasons {
+  /** Could not find the extension on the Visual Studio Marketplace using the given extension id */
+  notFound = 'not found',
+  /** Occures if the API failed to match any repository for the extension on Visual Studio Markplace */
+  noRepositoryFound = 'no repository found',
+  /** Occures when the API fails to download the package.json from the Github repo for the extension */
+  packageJsonNotDownload = 'package.json could not be downloaded',
+  /** Occures whent he API cannot find any theme contributions within the package.json from the Github repository */
+  noThemesContributed = 'no themes contributed within package.json',
+}

--- a/src/Enum.ts
+++ b/src/Enum.ts
@@ -9,7 +9,10 @@ export enum AccessState {
   Followers,
 
   /** Subscribers only */
-  Subscribers
+  Subscribers,
+
+  /** Moderators only */
+  Moderators,
 }
 
 /**

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -37,12 +37,12 @@ export class API {
       return {available: false, reason: ThemeNotAvailableReasons.notFound};
     }
     let body = await res.text();
-    const repoUrlMatches = body.match(/"GitHubLink":"https:\/\/github.com\/(?<url>(?:\w|\d|\S)+)\.git",/i);
-    if (!repoUrlMatches || !repoUrlMatches.groups) {
+    const repoUrlMatches = body.match(/"GitHubLink":"https:\/\/github.com\/((?:\w|\d|\S)+)\.git",/i);
+    if (!repoUrlMatches) {
       return {available: false, reason: ThemeNotAvailableReasons.noRepositoryFound};
     }
     
-    const repoUrl = `https://raw.githubusercontent.com/${repoUrlMatches.groups.url}/master/package.json`;
+    const repoUrl = `https://raw.githubusercontent.com/${repoUrlMatches[1]}/master/package.json`;
     
     res = await fetch (repoUrl);
     if (!res.ok) {

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -1,5 +1,5 @@
 
-import * as fetch from 'node-fetch';
+import fetch from 'node-fetch';
 import { keytar } from '../Common';
 import { KeytarKeys } from '../Enum';
 
@@ -12,7 +12,7 @@ export class API {
         const currentUserId = await keytar.getPassword(KeytarKeys.service, KeytarKeys.userId);
         if (accessToken && currentUserId) {
           const url = `https://api.twitch.tv/helix/users/follows?from_id=${twitchUserId}&to_id=${currentUserId}`;
-          const res = await fetch.default(url, { headers: { 'Authorization': `Bearer ${accessToken}` } });
+          const res = await fetch(url, { headers: { 'Authorization': `Bearer ${accessToken}` } });
           const json = await res.json();
           return (json.data.length > 0) ? true: false;
         }
@@ -24,17 +24,17 @@ export class API {
 
   public static async getUserDetails(token: string | null) {
     const url = 'https://api.twitch.tv/helix/users';
-    const res = await fetch.default(url, { headers: { 'Authorization': `Bearer ${token}` } });
+    const res = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
     const json = (await res.json());
     return json.data && json.data[0];
   }
 
   public static async isValidExtensionName(extensionName: string): Promise<boolean> {
-    const url = 'https://marketplace.visualstudiocode.com/items?itemName={extensionName}';
-    const res = await fetch.default(url);
+    const url = `https://marketplace.visualstudio.com/items?itemName=${extensionName}`;
+    const res = await fetch(url, { method: 'GET', headers: { "Accept": "*/*", "User-Agent": "VSCode-Twitch-Themer" } });
     if (res.status === 404) {
       return false;
     }
-    return true;
+    return res.ok;
   }
 }

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -28,4 +28,13 @@ export class API {
     const json = (await res.json());
     return json.data && json.data[0];
   }
+
+  public static async isValidExtensionName(extensionName: string): Promise<boolean> {
+    const url = 'https://marketplace.visualstudiocode.com/items?itemName={extensionName}';
+    const res = await fetch.default(url);
+    if (res.status === 404) {
+      return false;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
# Purpose

As described in issue #93, it would be awesome if viewers could install themes they would like to be able to switch to. This PR attempts to close that issue.

# How it works

- The viewer will need to use the following command: `!theme install {extension unique identifier}`. The identifier is found on the marketplace' webpage for the theme.
- The 'themer' will ask the broadcaster if it is OK to install the theme. (There is an option to auto-install if you want).
- If the broadcaster 'Accept's the install, the theme will install.
- The viewer will then be able to switch to the themes contained within the theme extension.

# Example Video

![vscode-twitch-themer-install-cmd](https://user-images.githubusercontent.com/8602418/62437970-422f8300-b6fa-11e9-8990-93f78fa2cb59.gif)

# Behind the scenes

- I use the API static class to verify that the extension exists in the Visual Studio marketplace.
- If the extension exists, the API will then determine the public Github repo from the metadata within the marketplace website.
- The API will then download the `package.json` from the extensions Github repo and inspect the JSON to ensure that it contributes at least one theme.
- If the extension contributes an extension then VSCODE will prompt the broadcaster to install the extension (or install automatically if set).

![bitmoji](https://render.bitstrips.com/v2/cpanel/09501742-87e5-4631-a9af-e19c4558189b-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)