### PR TITLE
HOTFIX: Fixed an issue where some themes were not identified.

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -67,7 +67,7 @@ export class API {
       return {available: false, reason: ThemeNotAvailableReasons.noRepositoryFound};
     }
     
-    const repoUrl = `https://raw.githubusercontent.com/${repoUrlMatches[1]}/master/package.json`;
+    const repoUrl = `https://raw.githubusercontent.com/${repoUrlMatches[1].replace('.git','')}/master/package.json`;
     
     res = await fetch (repoUrl);
     if (!res.ok) {


### PR DESCRIPTION
Unfortunately, the matched group from the regex included the '.git' which broke our pull of the package.json from GitHub. I fixed it by replacing '.git' to '' if it exists.