### PR TITLE
Refactoring API class

### DIFF
--- a/azurepipelines.yaml
+++ b/azurepipelines.yaml
@@ -69,7 +69,7 @@ jobs:
   condition: succeeded()
   
   pool: 
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   
   steps:
   - task: NodeTool@0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-twitch-themer",
-	"version": "1.5.0",
+	"version": "1.6.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "mike@sparcapp.io"
   },
   "icon": "resources/logo.png",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "preview": false,
   "engines": {
     "vscode": "^1.32.0"

--- a/src/Authentication.ts
+++ b/src/Authentication.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import * as path from 'path';
 import * as url from 'url';
 import { v4 } from 'uuid';
-import { API } from './api/API';
+import { API, CLIENT_ID } from './api/API';
 import { KeytarKeys } from './Enum';
 
 import { keytar } from './Common';
@@ -61,7 +61,7 @@ export class AuthenticationService {
         this.createServer(state);
         vscode.env.openExternal(
           vscode.Uri.parse(
-            `https://id.twitch.tv/oauth2/authorize?client_id=ts9wowek7hj9yw0q7gmg27c29i6etn` +
+            `https://id.twitch.tv/oauth2/authorize?client_id=${CLIENT_ID}` +
               `&redirect_uri=http://localhost:5544` +
               `&response_type=token&scope=chat:edit chat:read whispers:edit user:read:email` +
               `&state=${state}`

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -4,6 +4,8 @@ import { keytar } from '../Common';
 import { KeytarKeys, ThemeNotAvailableReasons } from '../Enum';
 import * as vscode from 'vscode';
 
+export const CLIENT_ID: string = 'ts9wowek7hj9yw0q7gmg27c29i6etn';
+
 export class API {
 
   public static async isTwitchUserFollowing(twitchUserId: string | undefined) {
@@ -13,7 +15,7 @@ export class API {
         const currentUserId = await keytar.getPassword(KeytarKeys.service, KeytarKeys.userId);
         if (accessToken && currentUserId) {
           const url = `https://api.twitch.tv/helix/users/follows?from_id=${twitchUserId}&to_id=${currentUserId}`;
-          const res = await fetch(url, { headers: { 'Authorization': `Bearer ${accessToken}`, 'client-id': 'ts9wowek7hj9yw0q7gmg27c29i6etn' } });
+          const res = await fetch(url, { headers: { 'Authorization': `Bearer ${accessToken}`, 'client-id': CLIENT_ID } });
           const json = await res.json();
           return (json.data.length > 0) ? true: false;
         }
@@ -25,7 +27,7 @@ export class API {
 
   public static async getUserDetails(token: string | null) {
     const url = 'https://api.twitch.tv/helix/users';
-    const res = await fetch(url, { headers: { 'Authorization': `Bearer ${token}`, 'client-id': 'ts9wowek7hj9yw0q7gmg27c29i6etn' } });
+    const res = await fetch(url, { headers: { 'Authorization': `Bearer ${token}`, 'client-id': CLIENT_ID } });
     const json = (await res.json());
     return json.data && json.data[0];
   }
@@ -90,7 +92,7 @@ export class API {
       const currentUserId = await keytar.getPassword(KeytarKeys.service, KeytarKeys.userId);
       if (accessToken && currentUserId) {
         const url = `https://api.twitch.tv/helix/streams?user_id=${currentUserId}`;
-        const res = await fetch(url, { headers: { 'Authorization': `Bearer ${accessToken}`, 'client-id': 'ts9wowek7hj9yw0q7gmg27c29i6etn' } });
+        const res = await fetch(url, { headers: { 'Authorization': `Bearer ${accessToken}`, 'client-id': CLIENT_ID } });
         const json = await res.json();
         return (json.data.length > 0) ? true : false;
       }


### PR DESCRIPTION
- Moved client id into a `CLIENT_ID` constant rather than repeating it 4 times in the code. 
- Exported the constant due to it being used in `Authentication.ts` class, replaced the instance of the string with our new const.