### PR TITLE
Fixed an issue when verifying contributes contains themes

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -76,8 +76,8 @@ export class API {
     
     const packageFile = await res.text();
     const packageJson = JSON.parse(packageFile);
-    
-    if (packageJson.contributes.themes.length === 0) {
+
+    if (!packageJson.contributes.themes || packageJson.contributes.themes.length === 0) {
       return { available: false, reason: ThemeNotAvailableReasons.noThemesContributed };
     }
     


### PR DESCRIPTION
Since `packageJson.contributes.themes` maybe `null` we need to add a check for this possibility before we check to ensure that it is not empty. This fixes that issue.