### PR TITLE
Quick Fix: Add an else statement for missing Twitch creds

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -17,6 +17,9 @@ export class API {
           const res = await fetch(url, { headers: { 'Authorization': `Bearer ${accessToken}`, 'client-id': 'ts9wowek7hj9yw0q7gmg27c29i6etn' } });
           const json = await res.json();
           return (json.data.length > 0) ? true: false;
+        } else {
+          logger.debug('failed to retrieve Twitch credentials from the user store');
+          return false;
         }
       }
     }


### PR DESCRIPTION
During the stream on July 28, we noticed an incorrect reason as to why a user could not be determined if they were a follower or not. It turns out that the actual problem was that the API could not retrieve the Twitch credentials. The inaccurate logged event occurred because there was no 'else' statement where we check that the 'accessToken' and 'currentUserId' variables are populated with a value. This PR is a quick fix to add the needed 'else' statement.